### PR TITLE
better terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ func main() {
 func longRunningTaskThatMightFail(ctx context.Context, hc *health.Check) {
 	for ctx.Err() == nil {
 		if err := mightFail(ctx); err != nil {
-			// the component failed, unset it and retry
-			hc.Unset("component") 
+			// the component failed
+			hc.Fail("component") 
 
 			pause.For(ctx, time.Second)
 
 			continue
 		}
-		hc.Set("component") // the component did not fail; carry on
+		hc.Pass("component") // the component did not fail; carry on
 
 		// ...
 	}

--- a/health.go
+++ b/health.go
@@ -34,8 +34,8 @@ type Check struct {
 	components map[string]struct{}
 }
 
-// Set sets the given components of the Check to not failing.
-func (c *Check) Set(components ...string) {
+// Pass sets the given components of the Check to not failing.
+func (c *Check) Pass(components ...string) {
 	if len(components) == 0 {
 		return
 	}
@@ -48,8 +48,8 @@ func (c *Check) Set(components ...string) {
 	}
 }
 
-// Unset sets the given components of the Check to failing.
-func (c *Check) Unset(components ...string) {
+// Fail sets the given components of the Check to failing.
+func (c *Check) Fail(components ...string) {
 	if len(components) == 0 {
 		return
 	}

--- a/health_test.go
+++ b/health_test.go
@@ -44,23 +44,23 @@ func TestServeHTTP(t *testing.T) {
 	)
 
 	empty := &Check{}
-	empty.Set()
-	empty.Unset("1")
-	empty.Unset("2")
-	empty.Unset("3", "4", "5")
-	empty.Set("3", "4", "5")
-	empty.Set("2")
-	empty.Set("1")
-	empty.Unset()
+	empty.Pass()
+	empty.Fail("1")
+	empty.Fail("2")
+	empty.Fail("3", "4", "5")
+	empty.Pass("3", "4", "5")
+	empty.Pass("2")
+	empty.Pass("1")
+	empty.Fail()
 
 	healthy := new(Check)
-	healthy.Set("1", "3")
-	healthy.Unset("2")
-	healthy.Set("2")
+	healthy.Pass("1", "3")
+	healthy.Fail("2")
+	healthy.Pass("2")
 
 	unhealthy := new(Check)
-	unhealthy.Unset("1", "2", "3")
-	unhealthy.Set("2")
+	unhealthy.Fail("1", "2", "3")
+	unhealthy.Pass("2")
 
 	cases := []*testCase{
 		// tests on empty
@@ -120,7 +120,7 @@ func TestFailing(t *testing.T) {
 
 	var c Check
 	for i := len(dst); i < cap(dst); i++ {
-		c.Unset(strconv.Itoa(i))
+		c.Fail(strconv.Itoa(i))
 	}
 	got := c.Failing(dst[len(dst):])
 


### PR DESCRIPTION
This PR renames `Set` to `Pass` and `Unset` to `Fail`.